### PR TITLE
fix display of href

### DIFF
--- a/resources/views/lily/show.blade.php
+++ b/resources/views/lily/show.blade.php
@@ -147,10 +147,11 @@ $resource_qs = '?v'.explode(' ', config('lemonade.version'))[0];
                                         $past_legion_name .= ' ('.$triples[$past_legion]['schema:alternateName'][0].')';
                                     }
                                     ?>
-                                    <a href="{{ route('legion.show',['legion' => str_replace('lilyrdf:','',$past_legion)]) }}"
-                                       style="display: block">
-                                        {{ $past_legion_name }}
-                                    </a>
+                                    <div>
+                                        <a href="{{ route('legion.show',['legion' => str_replace('lilyrdf:','',$past_legion)]) }}">
+                                            {{ $past_legion_name }}
+                                        </a>
+                                    </div>
                                 @endforeach
                             </td>
                         </tr>
@@ -167,10 +168,11 @@ $resource_qs = '?v'.explode(' ', config('lemonade.version'))[0];
                                         $taskforce_name .= ' ('.$triples[$taskforce]['schema:alternateName'][0].')';
                                     }
                                     ?>
-                                    <a href="{{ route('legion.show',['legion' => str_replace('lilyrdf:','',$taskforce)]) }}"
-                                       style="display: block">
-                                        {{ $taskforce_name }}
-                                    </a>
+                                    <div>
+                                        <a href="{{ route('legion.show',['legion' => str_replace('lilyrdf:','',$taskforce)]) }}">
+                                            {{ $taskforce_name }}
+                                        </a>
+                                    </div>
                                 @endforeach
                             </td>
                         </tr>
@@ -187,10 +189,11 @@ $resource_qs = '?v'.explode(' ', config('lemonade.version'))[0];
                                         $past_taskforce_name .= ' ('.$triples[$past_taskforce]['schema:alternateName'][0].')';
                                     }
                                     ?>
-                                    <a href="{{ route('legion.show',['legion' => str_replace('lilyrdf:','',$past_taskforce)]) }}"
-                                       style="display: block">
-                                        {{ $past_taskforce_name }}
-                                    </a>
+                                    <div>
+                                        <a href="{{ route('legion.show',['legion' => str_replace('lilyrdf:','',$past_taskforce)]) }}">
+                                            {{ $past_taskforce_name }}
+                                        </a>
+                                    </div>
                                 @endforeach
                             </td>
                         </tr>


### PR DESCRIPTION
一部の項目だけリンクの表示が `display: block` になっていてリンク領域が行いっぱいに伸びてしまっているので修正します。

※修正前はこうなっていました。このタイプのリンクで空白領域までリンクになっているのは良くないと思います。
![無題](https://user-images.githubusercontent.com/8458066/164643940-c375a4c5-fe43-4c7a-b1fd-2c5db00156cb.png)

