### PR TITLE
LuciaDB 更新情報に Lemonade の詳細ページへのリンク生成機能を追加

### DIFF
--- a/resources/views/main/home.blade.php
+++ b/resources/views/main/home.blade.php
@@ -199,7 +199,7 @@ $ogp['title'] = "アサルトリリィファンサイト";
                             <td>{{ date('Y/m/d H:i', strtotime($entry->updated)) }}</td>
                             <td><a href="{{ $entry->link->attributes()->href }}" target="_blank" class="button smaller"
                                    title="GitHubのコミットログ詳細を開きます">GitHub</a></td>
-                            <td style="text-align: left">{{ $entry->title }}</td>
+                            <td style="text-align: left">{!! $entry->title !!}</td>
                         </tr>
                     @endforeach
                 @else


### PR DESCRIPTION
## 概要
トップページにある LuciaDB 更新情報 の概要欄の文字列中に、LuciaDB に `schema:name` として登録されている文字列があったら、該当の文字列部分を Lemonade 内の該当のリソースの詳細ページへのリンクに置き換える機能を追加します。

![image](https://user-images.githubusercontent.com/8458066/201482502-2816bd7e-bfd7-4216-bae3-0d9bb08210f8.png)

### 懸念事項
二重ループを含むのでトップページの表示速度への影響が多少あるかも。