### PR TITLE
LuciaDBの更新情報が正しく生成できないことがあるバグを修正

### DIFF
--- a/app/Http/Controllers/MainController.php
+++ b/app/Http/Controllers/MainController.php
@@ -24,17 +24,11 @@ PREFIX schema: <http://schema.org/>
 
 SELECT ?subject ?predicate ?object
 WHERE {
-  {
-    VALUES ?predicate { rdf:type }
-    VALUES ?object { lily:Lily lily:Teacher lily:Madec lily:Character lily:Legion lily:Taskforce lily:Charm lily:Book lily:Play lily:AnimeSeries }
-    ?subject ?predicate ?object .
-  }
-  UNION
-  {
-    VALUES ?predicate { schema:name }
-    ?subject ?predicate ?object .
-    FILTER(lang(?object) = "ja")
-  }
+  VALUES ?predicate { schema:name rdf:type }
+  VALUES ?type { lily:Lily lily:Teacher lily:Madec lily:Character lily:Legion lily:Taskforce lily:Charm lily:Book lily:Play lily:AnimeSeries }
+  ?subject ?predicate ?object ;
+           a          ?type .
+  FILTER(!isLiteral(?object) || lang(?object) = "ja")
   FILTER(!isBlank(?subject))
 }
 SPARQL


### PR DESCRIPTION
修正前
![image](https://user-images.githubusercontent.com/8458066/221880910-b3b343ae-5efd-4e58-8678-476a791fa86f.png)

修正後
![image](https://user-images.githubusercontent.com/8458066/221881244-650b92f1-b20f-49b9-8a4c-ba15cdf73994.png)

### エラー内容
```
production.ERROR: Undefined array key "rdf:type" {"exception":"[object] (ErrorException(code: 0): Undefined array key \"rdf:type\" at /home/ubuntu/prj/Lemonade/app/Http/Controllers/MainController.php:49)
```

### 原因
詳細ページへのリンク生成 (#344) の対象外であるデータ型 (今回の場合は `lily:Music`) のデータを LuciaDB から取得してしまっており、更新情報に含まれる「シュベスターの祈り」が、`lily:Music` 型のデータ `lilyrdf:Song_Schwester_No_Inori` の `schema:name` と一致していたため。

修正前のクエリは

```sparql
{
  VALUES ?predicate { rdf:type }
  VALUES ?object { lily:Lily lily:Teacher lily:Madec lily:Character lily:Legion lily:Taskforce lily:Charm lily:Book lily:Play lily:AnimeSeries }
  ?subject ?predicate ?object .
}
```

と

```sparql
{
  VALUES ?predicate { schema:name }
  ?subject ?predicate ?object .
  FILTER(lang(?object) = "ja")
}
```

を個別のWHERE句として実行し結果を `UNION` するクエリであるので、前者の `VALUES ?object { ... }` で拾ってくるデータ型の条件を付けていても後者のクエリの条件としては機能していませんでした。

### やったこと
SPARQLクエリを修正し、`VALUES ?type { ... }` で指定した型以外のデータは一切取得されないようにしました。