### PR TITLE
fix typo

### DIFF
--- a/resources/views/main/menu.blade.php
+++ b/resources/views/main/menu.blade.php
@@ -44,7 +44,7 @@ $ogp['title'] = "サイトメニュー";
         <h2>プチ機能</h2>
         <div class="buttons three">
             <a href="{{ route('imedic') }}" class="button">アサルトリリィIME辞書生成</a>
-            <a href="{{ route('queryEditor') }}" class="button">SPARQLクエリエディタ―</a>
+            <a href="{{ route('queryEditor') }}" class="button">SPARQLクエリエディター</a>
         </div>
 
         <h2>このウェブサイトについて</h2>


### PR DESCRIPTION
ー(長音記号)が―(ダッシュ記号)になってるのを見つけました。
これ以外にダッシュ記号になっているところはありませんでした。