### PR TITLE
一部CHARMでリンク付けが正常に動作しない問題の修正

### DIFF
--- a/app/Http/Controllers/MainController.php
+++ b/app/Http/Controllers/MainController.php
@@ -30,7 +30,7 @@ WHERE {
            a          ?type .
   FILTER(!isLiteral(?object) || lang(?object) = "ja")
   FILTER(!isBlank(?subject))
-}ORDER BY DESC(?object)
+}ORDER BY DESC(strlen(?object))
 SPARQL
 );
             $name_list = sparqlToArray($name_list_rdf);


### PR DESCRIPTION
#414 では前に文字が付くような派生CHARMに対応できていなかったため、修正を行います。